### PR TITLE
path variables match anything but /

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 let package = Package(
 	name: "Router",
 	dependencies: [
-        .Package(url: "https://github.com/Zewo/HTTP.git", majorVersion: 0, minor: 1),
+        .Package(url: "https://github.com/RikEnde/HTTP.git", majorVersion: 0, minor: 1),
         .Package(url: "https://github.com/Zewo/CURIParser.git", majorVersion: 0, minor: 1),
 	]
 )

--- a/Sources/Router.swift
+++ b/Sources/Router.swift
@@ -41,15 +41,18 @@ public struct Router: ResponderType {
             self.methods = methods
             self.routeRespond = routeRespond
 
-            let parameterRegularExpression = try! Regex(pattern: ":([[:alnum:]]+)")
-            let pattern = parameterRegularExpression.replace(path, withTemplate: "([[:alnum:]_-]+)")
+            let parameterRegularExpression = try! Regex(pattern: ":([^/]+)")
+            let pattern = parameterRegularExpression.replace(path, withTemplate: "([^/]+)")
 
             self.parameterKeys = parameterRegularExpression.groups(path)
             self.regularExpression = try! Regex(pattern: "^" + pattern + "$")
         }
 
         func matchesRequest(request: Request) -> Bool {
-            return regularExpression.matches(request.uri.path!) && methods.contains(request.method)
+			if let path = request.uri.path {
+				return regularExpression.matches(path) && methods.contains(request.method)
+			}
+			return false
         }
 
         public  func respond(request: Request) throws -> Response {


### PR DESCRIPTION
Path variable matching was restricted to alphanumeric, - and _
I think it's safe to match url encoded keys with any token but / 

example:

curl http://localhost:8000/mammals/tree%20dwellers/  
